### PR TITLE
store samples in ets for types none and uniform

### DIFF
--- a/include/folsom.hrl
+++ b/include/folsom.hrl
@@ -14,7 +14,8 @@
 -record(uniform, {
 	  size = 5000,
 	  n = 1,
-	  reservoir = dict:new()
+	  reservoir = ets:new(folsom_uniform,[set]),
+	  seed = now()
 	 }).
 
 -record(exdec, {
@@ -26,9 +27,10 @@
          }).
 
 -record(none, {
-    size = 5000,
-    reservoir = []
-   }).
+	  size = 5000,
+	  n = 0,
+	  reservoir = ets:new(folsom_none,[ordered_set])
+	 }).
 
 -define(SYSTEM_INFO, [
                    allocated_areas,

--- a/src/folsom_sample_uniform.erl
+++ b/src/folsom_sample_uniform.erl
@@ -45,22 +45,20 @@
 new(Size) ->
     #uniform{size = Size}.
 
-%% update1(#uniform1{reservoir = dict} = Sample, Value) ->
-%%     Sample#uniform1{reservoir = [Value]};
 update(#uniform{size = Size, reservoir = Reservoir, n=N} = Sample, Value) when N =< Size ->
-    Sample#uniform{reservoir = dict:store(N, Value, Reservoir), n = N+1};
+    ets:insert(Reservoir, {N, Value}),
+    Sample#uniform{n = N+1};
 
-update(#uniform{reservoir = Reservoir, size = Size, n = N} = Sample, Value) ->
-    NewReservoir = maybe_update(rand(N), Size, Value, Reservoir),
-    Sample#uniform{reservoir = NewReservoir, n=N+1}.
+update(#uniform{reservoir = Reservoir, size = Size, n = N, seed=Seed} = Sample,
+       Value) ->
+    {Rnd, New_seed} = random:uniform_s(N, Seed),
+    maybe_update(Rnd, Size, Value, Reservoir),
+    Sample#uniform{n=N+1, seed=New_seed}.
 
 get_values(#uniform{reservoir = Reservoir}) ->
-    [Val || {_,Val} <- dict:to_list(Reservoir)].
+    [Val || {_,Val} <- ets:tab2list(Reservoir)].
 
 maybe_update(Rnd, Size, Value, Reservoir) when Rnd < Size ->
-    dict:store(Rnd, Value, Reservoir);
-maybe_update(_Rnd, _Size, _Value, Reservoir) ->
-    Reservoir.
-
-rand(Count) ->
-    random:uniform(Count).
+    ets:insert(Reservoir, {Rnd, Value});
+maybe_update(_Rnd, _Size, _Value, _Reservoir) ->
+    ok.


### PR DESCRIPTION
To avoid copying the complete datasets from and to ets for each
update, the samples are now stored in its own ets table.
