### PR TITLE
Bin calculation for histogram metric fixed

### DIFF
--- a/src/folsom_statistics.erl
+++ b/src/folsom_statistics.erl
@@ -323,8 +323,9 @@ get_hist_bins(Min, Max, StdDev, Count) ->
     case get_bin_list(BinWidth, BinCount, []) of
         List when length(List) =< 1 ->
             [Max];
-        Else ->
-            Else
+        Bins ->
+            %% add Min to Bins
+            [Bin + Min || Bin <- Bins]
     end.
 
 get_bin_list(Width, Bins, Acc) when Bins > length(Acc) ->


### PR DESCRIPTION
Following steps can be taken to reproduce the error:

`folsom_sup:start_link().`
`Fun = fun() -> timer:sleep(5) end.`
`folsom_metrics:new_histogram('hist').`
`[folsom_metrics:histogram_timed_update('hist', Fun) || Count <- lists:seq(1, 7)].`

We now have a histogram metric with 7 values and
`folsom_metrics:get_histogram_statistics('hist').`  will result in error, because the bins computed are incorrect.

The source of the problem is that the bins are computed as deltas (from Min) and not delta + Min.
