### PR TITLE
fix typo in folsom:stop/1

### DIFF
--- a/src/folsom.erl
+++ b/src/folsom.erl
@@ -55,5 +55,5 @@ start(_Type, _Args) ->
        {meter_reader, fun folsom_metrics:new_meter_reader/1}]),
     {ok, Pid}.
 
-stop(?APP) ->
+stop(_State) ->
     ok.


### PR DESCRIPTION
The argument to this is going to be the state, which will be [] by default not the name of the app.
