### PR TITLE
Catch delete of history table so a crashed process doesn't leave a mess

### DIFF
--- a/src/folsom_ets.erl
+++ b/src/folsom_ets.erl
@@ -211,11 +211,11 @@ maybe_add_handler(_, Name, _, _, _, true) ->
     {error, Name, metric_already_exists}.
 
 delete_metric(Name, history) when is_binary(Name) ->
-    true = ets:delete(folsom_utils:to_atom(Name)),
+    catch ets:delete(folsom_utils:to_atom(Name)),
     true = ets:delete(?FOLSOM_TABLE, Name),
     ok;
 delete_metric(Name, history) ->
-    true = ets:delete(Name),
+    catch ets:delete(Name),
     true = ets:delete(?FOLSOM_TABLE, Name),
     ok;
 delete_metric(Name, histogram) ->


### PR DESCRIPTION
In the case that the process that create a history metric crashes
it is unable to delete the metric from folsom and re-create it.
This addresses that. Ideally a process should be started when a
history is created, it should trap exists and recreate the
history table in the face of a crash. I'll do that later, honest.
