### PR TITLE
Add a 'spiral' one minute sliding window count/meter

### DIFF
--- a/include/folsom.hrl
+++ b/include/folsom.hrl
@@ -6,6 +6,7 @@
 -define(METER_READER_TABLE, folsom_meter_readers).
 -define(HISTORY_TABLE, folsom_histories).
 -define(DURATION_TABLE, folsom_durations).
+-define(SPIRAL_TABLE, folsom_spirals).
 
 -define(DEFAULT_LIMIT, 5).
 -define(DEFAULT_SIZE, 1028). % mimic codahale's metrics
@@ -13,6 +14,14 @@
 -define(DEFAULT_ALPHA, 0.015). % mimic codahale's metrics
 -define(DEFAULT_INTERVAL, 5000).
 -define(DEFAULT_SAMPLE_TYPE, uniform).
+
+-record(spiral, {
+          tid = folsom_metrics_histogram_ets:new(folsom_spiral,
+                                                 [ordered_set,
+                                                  {write_concurrency, true},
+                                                  public]),
+          server
+         }).
 
 -record(slide, {
           window = ?DEFAULT_SLIDING_WINDOW,

--- a/src/folsom_metrics.erl
+++ b/src/folsom_metrics.erl
@@ -39,6 +39,7 @@
          new_duration/2,
          new_duration/3,
          new_duration/4,
+         new_spiral/1,
          delete_metric/1,
          notify/1,
          notify/2,
@@ -102,6 +103,9 @@ new_duration(Name, SampleType, SampleSize) ->
 
 new_duration(Name, SampleType, SampleSize, Alpha) ->
     folsom_ets:add_handler(duration, Name, SampleType, SampleSize, Alpha).
+
+new_spiral(Name) ->
+    folsom_ets:add_handler(spiral, Name).
 
 delete_metric(Name) ->
     folsom_ets:delete_handler(Name).

--- a/src/folsom_metrics_spiral.erl
+++ b/src/folsom_metrics_spiral.erl
@@ -1,0 +1,74 @@
+%%%
+%%% Copyright 2012, Basho Technologies, Inc.  All Rights Reserved.
+%%%
+%%% Licensed under the Apache License, Version 2.0 (the "License");
+%%% you may not use this file except in compliance with the License.
+%%% You may obtain a copy of the License at
+%%%
+%%%     http://www.apache.org/licenses/LICENSE-2.0
+%%%
+%%% Unless required by applicable law or agreed to in writing, software
+%%% distributed under the License is distributed on an "AS IS" BASIS,
+%%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%%% See the License for the specific language governing permissions and
+%%% limitations under the License.
+%%%
+
+
+%%%-------------------------------------------------------------------
+%%% File:      folsom_metrics_spiral.erl
+%%% @author    Russell Brown <russelldb@basho.com>
+%%% @doc A total count, and sliding window count of events over the last
+%%%      minute.
+%%% @end
+%%%------------------------------------------------------------------
+
+-module(folsom_metrics_spiral).
+
+-export([new/1,
+         update/2,
+         trim/2,
+         get_value/1,
+         get_values/1
+        ]).
+
+%% size of the window in seconds
+-define(WINDOW, 60).
+
+-include("folsom.hrl").
+
+new(Name) ->
+    Spiral = #spiral{},
+    Pid = folsom_sample_slide_sup:start_slide_server(?MODULE,
+                                                           Spiral#spiral.tid,
+                                                           ?WINDOW),
+    ets:insert_new(Spiral#spiral.tid, {count, 0}),
+    ets:insert(?SPIRAL_TABLE, {Name, Spiral#spiral{server=Pid}}).
+
+update(Name, Value) ->
+    #spiral{tid=Tid} = get_value(Name),
+    Moment = folsom_utils:now_epoch(),
+    ets:insert_new(Tid, {Moment, 0}),
+    ets:update_counter(Tid, Moment, Value),
+    ets:update_counter(Tid, count, Value).
+
+get_value(Name) ->
+    [{Name, Spiral}] =  ets:lookup(?SPIRAL_TABLE, Name),
+    Spiral.
+
+trim(Tid, _Window) ->
+    Oldest = oldest(),
+    ets:select_delete(Tid, [{{'$1','_'}, [{is_integer, '$1'}, {'<', '$1', Oldest}], ['true']}]).
+
+get_values(Name) ->
+    Oldest = oldest(),
+    #spiral{tid=Tid} = get_value(Name),
+    [{count, Count}] = ets:lookup(Tid, count),
+    One =lists:sum(ets:select(Tid, [{{'$1','$2'},[{is_integer, '$1'}, {'>=', '$1', Oldest}],['$2']}])),
+
+    [{count, Count}, {one, One}].
+
+oldest() ->
+    folsom_utils:now_epoch() - ?WINDOW.
+
+

--- a/src/folsom_sup.erl
+++ b/src/folsom_sup.erl
@@ -107,7 +107,8 @@ create_tables() ->
               {?METER_TABLE, [set, named_table, public, {write_concurrency, true}]},
               {?METER_READER_TABLE, [set, named_table, public, {write_concurrency, true}]},
               {?HISTORY_TABLE, [set, named_table, public, {write_concurrency, true}]},
-              {?DURATION_TABLE, [ordered_set, named_table, public, {write_concurrency, true}]}
+              {?DURATION_TABLE, [ordered_set, named_table, public, {write_concurrency, true}]},
+              {?SPIRAL_TABLE, [set, named_table, public, {write_concurrency, true}]}
              ],
     [maybe_create_table(ets:info(Name), Name, Opts) || {Name, Opts} <- Tables],
     ok.


### PR DESCRIPTION
Riak metrics used a sliding one minute count and a total count for a bunch of metrics. The folsom meter's EWMA sample doesn't show the actual count of events in the last minute, wish Riak users expect, this module duplicates the behaviour of riak module 'spiraltime.erl' by maintaining a sliding window count for the last minute and a total since the metric started.
