### PR TITLE
Fix handling of c_compiler_used when erlang was compiled with MSC

### DIFF
--- a/src/folsom_vm_metrics.erl
+++ b/src/folsom_vm_metrics.erl
@@ -132,7 +132,9 @@ convert_allocated_areas({Key, Value}) ->
 convert_c_compiler_version({A, B, C}) ->
     list_to_binary(io_lib:format("~p.~p.~p", [A, B, C]));
 convert_c_compiler_version({A, B}) ->
-    list_to_binary(io_lib:format("~p.~p", [A, B])).
+    list_to_binary(io_lib:format("~p.~p", [A, B]));
+convert_c_compiler_version(A) ->
+    list_to_binary(io_lib:format("~p", [A])).
 
 convert_cpu_topology([{core, Value}| Tail], Acc) when is_tuple(Value) ->
     convert_cpu_topology(Tail, lists:append(Acc, [{core, tuple_to_list(Value)}]));

--- a/test/folsom_erlang_checks.erl
+++ b/test/folsom_erlang_checks.erl
@@ -33,7 +33,8 @@
          delete_metrics/0,
          vm_metrics/0,
          counter_metric/2,
-         cpu_topology/0
+         cpu_topology/0,
+         c_compiler_used/0
         ]).
 
 -define(DATA, [0, 1, 5, 10, 100, 200, 500, 750, 1000, 2000, 5000]).
@@ -348,6 +349,19 @@ run_convert_and_jsonify(Item) ->
     Result = folsom_vm_metrics:convert_system_info({cpu_topology, Item}),
     %?debugFmt("~p~n", [mochijson2:encode(Result)]).
     mochijson2:encode(Result).
+
+c_compiler_used() ->
+    Test = [{gnuc, {4,4,5}},
+            {gnuc, {4,4}},
+            {msc, 1600}],
+
+    Expected = [[{compiler, gnuc}, {version, <<"4.4.5">>}],
+                [{compiler, gnuc}, {version, <<"4.4">>}],
+                [{compiler, msc}, {version, <<"1600">>}]],
+
+    ?assertEqual(Expected, [folsom_vm_metrics:convert_system_info({c_compiler_used, {Compiler, Version}})
+                             || {Compiler, Version} <- Test]).
+
 
 duration_check(Duration) ->
     [?assert(lists:keymember(Key, 1, Duration)) || Key <-

--- a/test/folsom_tests.erl
+++ b/test/folsom_tests.erl
@@ -45,7 +45,9 @@ run_test_() ->
       {"deleting metrics",
        fun folsom_erlang_checks:delete_metrics/0},
       {"cpu topology test",
-       fun folsom_erlang_checks:cpu_topology/0}]}.
+       fun folsom_erlang_checks:cpu_topology/0},
+      {"c compiler test",
+       fun folsom_erlang_checks:c_compiler_used/0}]}.
 
 configure_test_() ->
     {foreach, fun setup_app/0, fun cleanup_app/1,


### PR DESCRIPTION
The tuple returned is in the format of {msc, number()}, and
convert_c_compiler_version was expecting the version to be a tuple.

Double checked this both in OTP and the MSDN to make sure there wasn't another problem along the way.

OTP generates the tuple in `erts/erl_bif_info.c` with something along the lines of:

``` c
#elif defined(_MSC_VER)
    return erts_bld_tuple(hpp,
                          szp,
                          2,
                          erts_bld_atom(hpp, szp, "msc"),
                          erts_bld_uint(hpp, szp, (Uint) _MSC_VER));
```

The MSDN indicates that _MSC_VER is just a number: http://msdn.microsoft.com/en-us/library/b0084kay.aspx.
