### PR TITLE
Fix for single-core CPU

### DIFF
--- a/src/folsom_vm_metrics.erl
+++ b/src/folsom_vm_metrics.erl
@@ -98,8 +98,10 @@ convert_system_info({c_compiler_used, {Compiler, Version}}) ->
     [{compiler, Compiler}, {version, convert_c_compiler_version(Version)}];
 convert_system_info({cpu_topology, undefined}) ->
     undefined;
-convert_system_info({cpu_topology, List}) ->
+convert_system_info({cpu_topology, List}) when is_list(List) ->
     [{Type, convert_cpu_topology(Item, [])} || {Type, Item} <- List];
+convert_system_info({cpu_topology, {logical,Item}}) ->
+    convert_system_info({cpu_topology, [{processor,[{core,{logical,Item}}]}]});
 convert_system_info({dist_ctrl, List}) ->
     lists:map(fun({Node, Socket}) ->
                       {ok, Stats} = inet:getstat(Socket),


### PR DESCRIPTION
This patch fixes boundary/folsom#32. Tested on my single-core ppc32.

Signed-off-by: Peter Lemenkov lemenkov@gmail.com
