### PR TITLE
Add a error tolerance notify method

### DIFF
--- a/src/folsom_metrics.erl
+++ b/src/folsom_metrics.erl
@@ -44,6 +44,9 @@
          notify/1,
          notify/2,
          notify/3,
+         safely_notify/1,
+         safely_notify/2,
+         safely_notify/3,
          notify_existing_metric/3,
          get_metrics/0,
          metric_exists/1,
@@ -120,6 +123,15 @@ notify(Name, Event) ->
 
 notify(Name, Event, Type) ->
     folsom_ets:notify(Name, Event, Type).
+
+safely_notify(Event) ->
+  catch notify(Event).
+
+safely_notify(Name, Event) ->
+  catch notify(Name, Event).
+
+safely_notify(Name, Event, Type) ->
+  catch notify(Name, Event, Type).
 
 notify_existing_metric(Name, Event, Type) ->
     folsom_ets:notify_existing_metric(Name, Event, Type).

--- a/test/folsom_erlang_checks.erl
+++ b/test/folsom_erlang_checks.erl
@@ -94,6 +94,11 @@ populate_metrics() ->
     ok = folsom_metrics:notify({counter2, {inc, 10}}),
     ok = folsom_metrics:notify({counter2, {dec, 7}}),
 
+    meck:new(folsom_ets),
+    meck:expect(folsom_ets, notify, fun(_Event) -> meck:exception(error, something_wrong_with_ets) end),
+    {'EXIT', {something_wrong_with_ets, _}} = folsom_metrics:safely_notify({unknown_counter, {inc, 1}}),
+    meck:unload(folsom_ets),
+
     ok = folsom_metrics:notify({<<"gauge">>, 2}),
 
     [ok = folsom_metrics:notify({<<"uniform">>, Value}) || Value <- ?DATA],


### PR DESCRIPTION
If folsom_sup is crashed then folsom's ets tables are deleted. In this case notify method raise the exception. 
I added error tolerance method to reduce the folsom's influence to the application code. We should not break the main application if we experiencing the problems 
