### PR TITLE
Remove ineffective assertion in duration test.

### DIFF
--- a/test/folsom_erlang_checks.erl
+++ b/test/folsom_erlang_checks.erl
@@ -452,5 +452,4 @@ duration_check(Duration) ->
                                                         kurtosis, percentile, histogram]],
     ?assertEqual(10, proplists:get_value(count, Duration)),
     Last = proplists:get_value(last, Duration),
-    ?assert(Last > 10000),
-    ?assert(Last < 15000).
+    ?assert(Last > 10000).


### PR DESCRIPTION
Erlang's timer:sleep/1 is inaccurate enough on some systems to cause this clause
to regularly fail.
