### PR TITLE
Change the order of delete cascade for `spiral'

### DIFF
--- a/src/folsom_ets.erl
+++ b/src/folsom_ets.erl
@@ -300,9 +300,9 @@ delete_metric(Name, meter_reader) ->
 delete_metric(Name, spiral) ->
     #spiral{tid=Tid, server=Pid} = folsom_metrics_spiral:get_value(Name),
     folsom_sample_slide_server:stop(Pid),
-    true = ets:delete(Tid),
     ets:delete(?SPIRAL_TABLE, Name),
     ets:delete(?FOLSOM_TABLE, Name),
+    ets:delete(Tid),
     ok.
 
 delete_histogram(Name, #histogram{type = uniform, sample = #uniform{reservoir = Reservoir}}) ->


### PR DESCRIPTION
A crash of `folsom_metrics_histogram_ets` leaves spirals broken.
The spiral ets table goes away, so it can not be updated, nor
can it be deleted and re-created due to the delete order of
metric table, spiral table, folsom table. Have changed the order
to be more like that of `histogram` so deletes will succeed in
the event of a missing `spiral` ets table.

(Addresses https://github.com/boundary/folsom/issues/55)
