### PR TITLE
Let the slide server crash and stay crashed after multiple errors

### DIFF
--- a/src/folsom_sample_slide_sup.erl
+++ b/src/folsom_sample_slide_sup.erl
@@ -44,7 +44,7 @@ start_slide_server(SampleMod, Reservoir, Window) ->
 
 %% @private
 init ([]) ->
-    {ok,{{simple_one_for_one,10,10},
+    {ok,{{simple_one_for_one, 3, 180},
          [
           {undefined, {folsom_sample_slide_server, start_link, []},
            transient, brutal_kill, worker, [folsom_sample_slide_server]}


### PR DESCRIPTION
The restart strategy on the slide server was such that it would
_never_ stop in the case that the ets table it was trimming went away.
Instead it would metronimically add a crash message to your log
every 30 seconds. This commit sets the restart strategy to 3
failures in 3 minutes. Since the only seen live examples of
a slide server crash have been when the ets table has gone
away, it is best crash and stay dead than be restarted after
3 failed trims.
