### PR TITLE
Fix a race against querying the ETS/DETS tables.

### DIFF
--- a/src/folsom_vm_metrics.erl
+++ b/src/folsom_vm_metrics.erl
@@ -230,7 +230,11 @@ get_socket_sockname(Socket) ->
     end.
 
 get_ets_dets_info(Type, Tab) ->
-    [{Key, pid_port_fun_to_atom(Value)} || {Key, Value} <- Type:info(Tab)].
+    case Type:info(Tab) of
+        undefined -> [];
+        Entries when is_list(Entries) ->
+            [{Key, pid_port_fun_to_atom(Value)} || {Key, Value} <- Entries]
+    end.
 
 ip_to_binary(Tuple) ->
     iolist_to_binary(string:join(lists:map(fun integer_to_list/1, tuple_to_list(Tuple)), ".")).


### PR DESCRIPTION
There is a window from the query of, say, `ets:all()` to the point where we fetch out the table data. The table may disappear in between. This patch fixes this problem by ignoring such tables and returning the empty list for those where there is no data available anymore.

Please read through this patch carefully. I think it works, but it has not seen much testing apart from the bare necessities. That is, it doesn't change the common path.
