### PR TITLE
Add histogram of type 'slide_sorted'

### DIFF
--- a/include/folsom.hrl
+++ b/include/folsom.hrl
@@ -61,6 +61,12 @@
           reservoir = folsom_metrics_histogram_ets:new(folsom_none,[ordered_set, {write_concurrency, true}, public])
          }).
 
+-record(slide_sorted, {
+          size = ?DEFAULT_SIZE,
+          n = 0,
+          reservoir = folsom_metrics_histogram_ets:new(folsom_slide_sorted,[ordered_set, {write_concurrency, true}, public])
+         }).
+
 -record(histogram, {
           type = uniform,
           sample = #uniform{}

--- a/src/folsom_ets.erl
+++ b/src/folsom_ets.erl
@@ -315,6 +315,11 @@ delete_histogram(Name, #histogram{type = none, sample = #none{reservoir = Reserv
     true = ets:delete(?FOLSOM_TABLE, Name),
     true = ets:delete(Reservoir),
     ok;
+delete_histogram(Name, #histogram{type = slide_sorted, sample = #slide_sorted{reservoir = Reservoir}}) ->
+    true = ets:delete(?HISTOGRAM_TABLE, Name),
+    true = ets:delete(?FOLSOM_TABLE, Name),
+    true = ets:delete(Reservoir),
+    ok;
 delete_histogram(Name, #histogram{type = exdec}) ->
     true = ets:delete(?HISTOGRAM_TABLE, Name),
     true = ets:delete(?FOLSOM_TABLE, Name),

--- a/src/folsom_sample.erl
+++ b/src/folsom_sample.erl
@@ -54,6 +54,8 @@ new(uniform, Size, _) ->
     folsom_sample_uniform:new(Size);
 new(none, Size, _) ->
     folsom_sample_none:new(Size);
+new(slide_sorted, Size, _) ->
+    folsom_sample_slide_sorted:new(Size);
 new(exdec, Size, Alpha) ->
     folsom_sample_exdec:new(Size, Alpha).
 
@@ -61,6 +63,8 @@ update(uniform, Sample, Value) ->
     folsom_sample_uniform:update(Sample, Value);
 update(none, Sample, Value) ->
     folsom_sample_none:update(Sample, Value);
+update(slide_sorted, Sample, Value) ->
+    folsom_sample_slide_sorted:update(Sample, Value);
 update(exdec, Sample, Value) ->
     folsom_sample_exdec:update(Sample, Value);
 update(slide, Sample, Value) ->
@@ -73,6 +77,8 @@ get_values(uniform, Sample) ->
     folsom_sample_uniform:get_values(Sample);
 get_values(none, Sample) ->
     folsom_sample_none:get_values(Sample);
+get_values(slide_sorted, Sample) ->
+    folsom_sample_slide_sorted:get_values(Sample);
 get_values(exdec, Sample) ->
     folsom_sample_exdec:get_values(Sample);
 get_values(slide, Sample) ->

--- a/src/folsom_sample_slide_sorted.erl
+++ b/src/folsom_sample_slide_sorted.erl
@@ -1,0 +1,52 @@
+%%%
+%%% Copyright 2011, Boundary
+%%%
+%%% Licensed under the Apache License, Version 2.0 (the "License");
+%%% you may not use this file except in compliance with the License.
+%%% You may obtain a copy of the License at
+%%%
+%%%     http://www.apache.org/licenses/LICENSE-2.0
+%%%
+%%% Unless required by applicable law or agreed to in writing, software
+%%% distributed under the License is distributed on an "AS IS" BASIS,
+%%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%%% See the License for the specific language governing permissions and
+%%% limitations under the License.
+%%%
+
+
+%%%-------------------------------------------------------------------
+%%% File:      folsom_sample_slide_sorted.erl
+%%% @author    Ramon Lastres <ramon.lastres@erlang-solutions.com>
+%%% @doc
+%%% simple sliding window histogram.
+%%% @end
+%%%-----------------------------------------------------------------
+
+-module(folsom_sample_slide_sorted).
+
+-export([
+         new/1,
+         update/2,
+         get_values/1
+        ]).
+
+-include("folsom.hrl").
+
+new(Size) ->
+    #slide_sorted{size = Size}.
+
+update(#slide_sorted{size = Size, reservoir = Reservoir, n = N} = Sample, Value)
+  when N < Size ->
+    ets:insert(Reservoir, {os:timestamp(), Value}),
+    Sample#slide_sorted{n = N + 1};
+update(#slide_sorted{reservoir = Reservoir, n = N, size = Size} = Sample, Value)
+  when N == Size ->
+    Oldest = ets:first(Reservoir),
+    ets:delete(Reservoir, Oldest),
+    ets:insert(Reservoir, {os:timestamp(), Value}),
+    Sample.
+
+get_values(#slide_sorted{reservoir = Reservoir}) ->
+    {_, Values} = lists:unzip(ets:tab2list(Reservoir)),
+    Values.

--- a/test/folsom_erlang_checks.erl
+++ b/test/folsom_erlang_checks.erl
@@ -63,6 +63,8 @@ create_metrics() ->
     ok = folsom_metrics:new_histogram(noneb, none, 10),
     ok = folsom_metrics:new_histogram(nonec, none, 5),
 
+    ok = folsom_metrics:new_histogram(slide_sorted_a, slide_sorted, 10),
+
     ok = folsom_metrics:new_histogram(timed, none, 5000),
     ok = folsom_metrics:new_histogram(timed2, none, 5000),
 
@@ -90,7 +92,7 @@ create_metrics() ->
     %% check a server got started for the spiral metric
     1 = length(supervisor:which_children(folsom_sample_slide_sup)),
 
-    17 = length(folsom_metrics:get_metrics()),
+    18 = length(folsom_metrics:get_metrics()),
 
     ?debugFmt("~n~nmetrics: ~p~n", [folsom_metrics:get_metrics()]).
 
@@ -135,6 +137,8 @@ populate_metrics() ->
     [ok = folsom_metrics:notify({noneb, Value}) || Value <- ?DATA2],
 
     [ok = folsom_metrics:notify({nonec, Value}) || Value <- ?DATA2],
+
+    [ok = folsom_metrics:notify({slide_sorted_a, Value}) || Value <- ?DATA2],
 
     3.141592653589793 = folsom_metrics:histogram_timed_update(timed, math, pi, []),
 
@@ -191,6 +195,8 @@ check_metrics() ->
     [11,12,13,14,15,6,7,8,9,10] = folsom_metrics:get_metric_value(noneb),
 
     [11,12,13,14,15] = folsom_metrics:get_metric_value(nonec),
+
+    [6,7,8,9,10,11,12,13,14,15] = folsom_metrics:get_metric_value(slide_sorted_a),
 
     Histogram1 = folsom_metrics:get_histogram_statistics(<<"uniform">>),
     histogram_checks(Histogram1),
@@ -296,7 +302,7 @@ check_group_metrics() ->
     {counter, 0} = lists:keyfind(counter,1,Metrics).
 
 delete_metrics() ->
-    19 = length(ets:tab2list(?FOLSOM_TABLE)),
+    20 = length(ets:tab2list(?FOLSOM_TABLE)),
 
     ok = folsom_metrics:delete_metric(counter),
     ok = folsom_metrics:delete_metric(counter2),
@@ -313,6 +319,8 @@ delete_metrics() ->
     ok = folsom_metrics:delete_metric(nonea),
     ok = folsom_metrics:delete_metric(noneb),
     ok = folsom_metrics:delete_metric(nonec),
+
+    ok = folsom_metrics:delete_metric(slide_sorted_a),
 
     ok = folsom_metrics:delete_metric(timed),
     ok = folsom_metrics:delete_metric(timed2),


### PR DESCRIPTION
It is a simple sliding window histogram of fixed size. The elements are always ordered so that they can be use with Pearson/Spearman correlations. 

I used os:timestamp() for performance reasons, but might be better to use time erlang:now() to guarantee that values are never overwritten.

I don't know whether you find this useful or not, but just in case...
