### PR TITLE
use meck 0.7.2

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -2,7 +2,7 @@
 
 {deps, [
     {'bear', ".*", {git, "git://github.com/boundary/bear.git", {tag, "0.1.3"}}},
-    {meck, ".*", {git, "git://github.com/eproxus/meck", "master"}}
+    {meck, ".*", {git, "git://github.com/eproxus/meck", {tag, "0.7.2"}}}
 ]}.
 
 {erl_opts, [debug_info]}.


### PR DESCRIPTION
Current boundary:master depends on eproxus/meck master branch. Due to a breaking change in meck the folsom eunit tests don't run anymore. This change uses meck 0.7.2 which is compatible with the current folsom master.
