### PR TITLE
Implement new metric to calculate min/max/mean statistics

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,13 @@ This is a sliding window in time over a stream of readings with a random uniform
 
     > folsom_metrics:new_histogram(Name, slide_uniform, {Secs::interger(), Size::integer()).
 
+##### Simple statistics
+
+Simple statistics is a counter to calculate min/max/mean for the one minute sliding window. It uses one ets table, works fast and consumes much less memory than slide uniform histograms.
+
+      > folsom_metrics:new_simple_statistics(Name).
+      > folsom_metrics:notify({Name, Value}).
+
 ##### Histories
 
 Histories are a collection of past events, such as errors or log messages.

--- a/include/folsom.hrl
+++ b/include/folsom.hrl
@@ -7,6 +7,7 @@
 -define(HISTORY_TABLE, folsom_histories).
 -define(DURATION_TABLE, folsom_durations).
 -define(SPIRAL_TABLE, folsom_spirals).
+-define(SIMPLE_STATISTICS_TABLE, folsom_simple_statistics).
 
 -define(DEFAULT_LIMIT, 5).
 -define(DEFAULT_SIZE, 1028). % mimic codahale's metrics
@@ -14,6 +15,10 @@
 -define(DEFAULT_ALPHA, 0.015). % mimic codahale's metrics
 -define(DEFAULT_INTERVAL, 5000).
 -define(DEFAULT_SAMPLE_TYPE, uniform).
+
+-define(DEFAULT_STATS_CLEANER_INTERVAL, 30000).
+-define(DEFAULT_STATS_INTERVAL, 10).
+-define(DEFAULT_STATS_SLIDE_SIZE, 6).
 
 -record(spiral, {
           tid = folsom_metrics_histogram_ets:new(folsom_spiral,

--- a/src/folsom_metrics.erl
+++ b/src/folsom_metrics.erl
@@ -40,6 +40,7 @@
          new_duration/3,
          new_duration/4,
          new_spiral/1,
+         new_simple_statistics/1,
          delete_metric/1,
          tag_metric/2,
          untag_metric/2,
@@ -92,6 +93,9 @@ new_histogram(Name, SampleType, SampleSize) ->
 
 new_histogram(Name, SampleType, SampleSize, Alpha) ->
     folsom_ets:add_handler(histogram, Name, SampleType, SampleSize, Alpha).
+
+new_simple_statistics(Name) ->
+    folsom_ets:add_handler(simple_statistics, Name).
 
 new_history(Name) ->
     folsom_metrics:new_history(Name, ?DEFAULT_SIZE).

--- a/src/folsom_metrics_simple_statistics.erl
+++ b/src/folsom_metrics_simple_statistics.erl
@@ -1,0 +1,87 @@
+%%%
+%%% Licensed under the Apache License, Version 2.0 (the "License");
+%%% you may not use this file except in compliance with the License.
+%%% You may obtain a copy of the License at
+%%%
+%%%     http://www.apache.org/licenses/LICENSE-2.0
+%%%
+%%% Unless required by applicable law or agreed to in writing, software
+%%% distributed under the License is distributed on an "AS IS" BASIS,
+%%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%%% See the License for the specific language governing permissions and
+%%% limitations under the License.
+%%%
+
+
+%%%-------------------------------------------------------------------
+%%% File:      folsom_metrics_simple_statistics.erl
+%%% @author    Andrey Vasenin <vasenin@aboutecho.com>
+%%% @doc Simple minute statistics in one ets table. It works much faster than
+%%%      slide uniform histogram and doesn't use so many ets tables
+%%% @end
+%%%------------------------------------------------------------------
+
+-module(folsom_metrics_simple_statistics).
+
+-export([update/2,
+         expire_all/0,
+         get_values/1]).
+
+-include("folsom.hrl").
+
+-record(interval, {
+          count = 0,
+          min = undefined,
+          max = undefined,
+          sum = 0}).
+
+update(Name, Value) ->
+    Current = current_slide(),
+    I = #interval{count = 1, min = Value, max = Value, sum = Value},
+    ets:insert(?SIMPLE_STATISTICS_TABLE, {{Name, Current}, merge(get_interval(Name, Current), I)}).
+
+get_values(Name) ->
+    Current = current_slide(),
+    LastMinuteIntervals = [get_interval(Name, I) || I <- lists:seq(Current - ?DEFAULT_STATS_SLIDE_SIZE, Current)],
+    #interval{count = Count,
+              min = Min,
+              max = Max,
+              sum = Sum} = lists:foldl(fun merge/2, #interval{}, LastMinuteIntervals),
+    L = [{count, Count},
+         {min, Min},
+         {max, Max},
+         {mean, get_mean(Sum, Count)}],
+    [ {K,V} || {K,V} <- L, V /= undefined ].
+
+expire_all() ->
+    ExpiredSlide = current_slide() - ?DEFAULT_STATS_SLIDE_SIZE,
+    ets:select_delete(?SIMPLE_STATISTICS_TABLE, [{{{'_', '$1'}, '_'},
+                                                [{is_integer, '$1'}, {'<', '$1', ExpiredSlide}],
+                                                ['true'] }]).
+
+% Private functions
+
+current_slide() ->
+    folsom_utils:now_epoch() div ?DEFAULT_STATS_INTERVAL.
+
+get_interval(Name, SlideNumber) ->
+    case ets:lookup(?SIMPLE_STATISTICS_TABLE, {Name, SlideNumber}) of
+        [{_, Interval}] -> Interval;
+        _ -> #interval{}
+    end.
+
+
+op(_Op, undefined, undefined) -> undefined;
+op(_Op, A, undefined) -> A;
+op(_Op, undefined, A) -> A;
+op(Op, A, B) -> apply(erlang, Op, [A, B]).
+
+merge(#interval{count = CountA, min = MinA, max = MaxA, sum = SumA},
+      #interval{count = CountB, min = MinB, max = MaxB, sum = SumB}) ->
+    #interval{count = CountA + CountB,
+              min = op(min, MinA, MinB),
+              max = op(max, MaxA, MaxB),
+              sum = SumA + SumB}.
+
+get_mean(_Sum, 0) -> undefined;
+get_mean(Sum, Count) -> Sum / Count.

--- a/src/folsom_metrics_spiral.erl
+++ b/src/folsom_metrics_spiral.erl
@@ -40,9 +40,8 @@
 
 new(Name) ->
     Spiral = #spiral{},
-    Pid = folsom_sample_slide_sup:start_slide_server(?MODULE,
-                                                           Spiral#spiral.tid,
-                                                           ?WINDOW),
+    Interval = timer:seconds(?WINDOW) div 2,
+    Pid = folsom_timer_server_sup:start_timer(Interval, ?MODULE, trim, [Spiral#spiral.tid, ?WINDOW]),
     ets:insert_new(Spiral#spiral.tid,
                    [{{count, N}, 0} || N <- lists:seq(0,?WIDTH-1)]),
     ets:insert(?SPIRAL_TABLE, {Name, Spiral#spiral{server=Pid}}).

--- a/src/folsom_sample_slide.erl
+++ b/src/folsom_sample_slide.erl
@@ -37,7 +37,8 @@
 
 new(Size) ->
     Sample = #slide{window = Size},
-    Pid = folsom_sample_slide_sup:start_slide_server(?MODULE, Sample#slide.reservoir, Sample#slide.window),
+    Interval = timer:seconds(Sample#slide.window) div 2,
+    Pid = folsom_timer_server_sup:start_timer(Interval, ?MODULE, trim, [Sample#slide.reservoir, Sample#slide.window]),
     Sample#slide{server=Pid}.
 
 update(#slide{reservoir = Reservoir} = Sample, Value) ->

--- a/src/folsom_sample_slide_uniform.erl
+++ b/src/folsom_sample_slide_uniform.erl
@@ -35,7 +35,8 @@
 
 new({Window, SampleSize}) ->
     Sample = #slide_uniform{window = Window, size = SampleSize},
-    Pid = folsom_sample_slide_sup:start_slide_server(?MODULE, Sample#slide_uniform.reservoir, Sample#slide_uniform.window),
+    Interval = timer:seconds(Sample#slide_uniform.window) div 2,
+    Pid = folsom_timer_server_sup:start_timer(Interval, ?MODULE, trim, [Sample#slide_uniform.reservoir, Sample#slide_uniform.window]),
     Sample#slide_uniform{server=Pid}.
 
 update(#slide_uniform{reservoir = Reservoir, size = Size} = Sample0, Value) ->

--- a/src/folsom_timer_server_sup.erl
+++ b/src/folsom_timer_server_sup.erl
@@ -1,6 +1,6 @@
 %% -------------------------------------------------------------------
 %%
-%% Copyright (c) 2011 Basho Technologies, Inc.
+%% Copyright (c) 2011, Basho Technologies, Inc.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -18,34 +18,35 @@
 %%
 %% -------------------------------------------------------------------
 %%%-------------------------------------------------------------------
-%%% File:      folsom_sample_slide_sup.erl
-%%% @author    Russell Brown <russelldb@basho.com>
+%%% File:      folsom_timer_server_sup.erl
+%%% @author    Russell Brown <russelldb@basho.com>,
+%%%            Andrey Vasenin <vasenin@aboutecho.com>
 %%% @doc
-%%% Starts simple_one_for_one children per slide sample
+%%% Supervisor for folsom's timers. It starts simple_one_to_one timer's
+%%% child specs
 %%% @end
 %%%-----------------------------------------------------------------
--module(folsom_sample_slide_sup).
+-module(folsom_timer_server_sup).
 -behaviour(supervisor).
 
-%% beahvior functions
--export([start_link/0,
-         init/1
-        ]).
+-export([start_link/0, init/1 ]).
 
-%% public functions
--export([start_slide_server/3]).
+-export([start_timer/4, stop_timer/1]).
 
 start_link () ->
     supervisor:start_link({local,?MODULE},?MODULE,[]).
 
-start_slide_server(SampleMod, Reservoir, Window) ->
-    {ok, Pid} = supervisor:start_child(?MODULE, [SampleMod, Reservoir, Window]),
+start_timer(Time, Module, Function, Args) ->
+    {ok, Pid} = supervisor:start_child(?MODULE, [Time, Module, Function, Args]),
     Pid.
 
-%% @private
+stop_timer(Pid) ->
+    folsom_timer_server:stop(Pid).
+
 init ([]) ->
     {ok,{{simple_one_for_one, 3, 180},
          [
-          {undefined, {folsom_sample_slide_server, start_link, []},
+          {undefined, {folsom_timer_server, start_link, []},
            transient, brutal_kill, worker, [folsom_sample_slide_server]}
          ]}}.
+

--- a/test/folsom_sample_slide_test.erl
+++ b/test/folsom_sample_slide_test.erl
@@ -56,7 +56,7 @@ exercise() ->
     %% unless we call trim
     %% so kill the trim server process
     #histogram{sample=Slide} = folsom_metrics_histogram:get_value(?HISTO),
-    ok = folsom_sample_slide_server:stop(Slide#slide.server),
+    ok = folsom_timer_server_sup:stop_timer(Slide#slide.server),
     Moments = lists:seq(1, ?RUNTIME),
     %% pump in 90 seconds worth of readings
     Moment = lists:foldl(fun(_X, Tick) ->

--- a/test/slide_statem_eqc.erl
+++ b/test/slide_statem_eqc.erl
@@ -142,7 +142,7 @@ new_histo() ->
     Ref = make_ref(),
     folsom_metrics:new_histogram(Ref, slide, ?WINDOW),
     #histogram{sample=Slide} = folsom_metrics_histogram:get_value(Ref),
-    ok = folsom_sample_slide_server:stop(Slide#slide.server),
+    ok = folsom_timer_server_sup:stop_timer(Slide#slide.server),
     {Ref, Slide}.
 
 tick(Moment) ->

--- a/test/slide_uniform_eqc.erl
+++ b/test/slide_uniform_eqc.erl
@@ -144,7 +144,7 @@ new_histo() ->
     Ref = make_ref(),
     folsom_metrics:new_histogram(Ref, slide_uniform, {?WINDOW, ?SIZE}),
     #histogram{sample=Slide} = folsom_metrics_histogram:get_value(Ref),
-    ok = folsom_sample_slide_server:stop(Slide#slide_uniform.server),
+    ok = folsom_timer_server_sup:stop_timer(Slide#slide_uniform.server),
     {Ref, Slide}.
 
 tick(Moment) ->


### PR DESCRIPTION
Implement new metric to calculate min/max/mean for one minute interval.
This metric is used to analyze latency for systems with huge amount of
metrics. We have more than 2000 latency metrics and usual histograms doesn't suit for us.
