### PR TITLE
Add bear to start applications

### DIFF
--- a/src/folsom.app.src
+++ b/src/folsom.app.src
@@ -8,7 +8,8 @@
                 folsom_sup]},
   {applications, [
                   kernel,
-                  stdlib
+                  stdlib,
+                  bear
                  ]},
   {env, []},
   {mod, {folsom, []}}


### PR DESCRIPTION
Bear is used in `folsom_metrics` and `folsom_metrics_duration` but not included in applications in folsom.app
