### PR TITLE
get random index of sample by random(Size) instead of random(N) to avoid...

### DIFF
--- a/src/folsom_sample_uniform.erl
+++ b/src/folsom_sample_uniform.erl
@@ -49,7 +49,7 @@ update(#uniform{size = Size, reservoir = Reservoir, n = N} = Sample, Value) when
 
 update(#uniform{reservoir = Reservoir, size = Size, n = N, seed = Seed} = Sample,
        Value) ->
-    {Rnd, New_seed} = random:uniform_s(N, Seed),
+    {Rnd, New_seed} = random:uniform_s(Size, Seed),
     maybe_update(Rnd, Size, Value, Reservoir),
     Sample#uniform{n = N + 1, seed = New_seed}.
 


### PR DESCRIPTION
The ets size of uniform sample gets larger and larger after a few days running.
