### PR TITLE
Update meck version requirement

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -2,7 +2,7 @@
 
 {deps, [
     {'bear', ".*", {git, "git://github.com/boundary/bear.git", master}},
-    {meck, ".*", {git, "git://github.com/eproxus/meck", {tag, "0.7.2"}}}
+    {meck, ".*", {git, "git://github.com/eproxus/meck", {tag, "0.8.1"}}}
 ]}.
 
 {erl_opts, [debug_info]}.


### PR DESCRIPTION
For better compatibility with https://github.com/basho/erlang_protobuffs
