### PR TITLE
Make compatible with R17

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -2,7 +2,7 @@
 
 {deps, [
     {'bear', ".*", {git, "git://github.com/boundary/bear.git", {tag, "0.8.1"}}},
-    {meck, ".*", {git, "git://github.com/eproxus/meck", {tag, "0.8.1"}}}
+    {meck, ".*", {git, "git://github.com/eproxus/meck", {tag, "0.8.2"}}}
 ]}.
 
 {erl_opts, [debug_info]}.


### PR DESCRIPTION
Fix compilation error:

```
Compiling ...deps/meck/src/meck_proc.erl failed:
...deps/meck/src/meck_proc.erl:51: type dict/0 is deprecated and will be removed in OTP 18.0; use use dict:dict/0 or preferably dict:dict/2                                                                          
...deps/meck/src/meck_proc.erl:408: type dict/0 is deprecated and will be removed in OTP 18.0; use use dict:dict/0 or preferably dict:dict/2                                                                         
...deps/meck/src/meck_proc.erl:445: type dict/0 is deprecated and will be removed in OTP 18.0; use use dict:dict/0 or preferably dict:dict/2                                                                         
...deps/meck/src/meck_proc.erl:446: type dict/0 is deprecated and will be removed in OTP 18.0; use use dict:dict/0 or preferably dict:dict/2                                                                         
...deps/meck/src/meck_proc.erl:476: type dict/0 is deprecated and will be removed in OTP 18.0; use use dict:dict/0 or preferably dict:dict/2                                                                         
...deps/meck/src/meck_proc.erl:477: type dict/0 is deprecated and will be removed in OTP 18.0; use use dict:dict/0 or preferably dict:dict/2                                                                         
...deps/meck/src/meck_proc.erl:482: type dict/0 is deprecated and will be removed in OTP 18.0; use use dict:dict/0 or preferably dict:dict/2                                                                         
...deps/meck/src/meck_proc.erl:483: type dict/0 is deprecated and will be removed in OTP 18.0; use use dict:dict/0 or preferably dict:dict/2                                                                         
...deps/meck/src/meck_proc.erl:488: type dict/0 is deprecated and will be removed in OTP 18.0; use use dict:dict/0 or preferably dict:dict/2                                                                         
...deps/meck/src/meck_proc.erl:489: type dict/0 is deprecated and will be removed in OTP 18.0; use use dict:dict/0 or preferably dict:dict/2                                                                         
ERROR: compile failed while processing ...deps/meck: rebar_abort
```
