### PR TITLE
Update counter without catching exceptions

### DIFF
--- a/include/folsom.hrl
+++ b/include/folsom.hrl
@@ -20,7 +20,9 @@
                                                  [set,
                                                   {write_concurrency, true},
                                                   public]),
-          server
+          server,
+          update = update_counter :: update_counter |
+                                     update_counter_no_exception
          }).
 
 -record(slide, {

--- a/src/folsom_ets.erl
+++ b/src/folsom_ets.erl
@@ -242,6 +242,10 @@ maybe_add_handler(history, Name, SampleSize, false) ->
     ok = folsom_metrics_history:new(Name),
     true = ets:insert(?FOLSOM_TABLE, {Name, #metric{type = history, history_size = SampleSize}}),
     ok;
+maybe_add_handler(spiral, Name, Update, false) ->
+    true = folsom_metrics_spiral:new(Name, Update),
+    true = ets:insert(?FOLSOM_TABLE, {Name, #metric{type = spiral}}),
+    ok;
 maybe_add_handler(Type, _, _, false) ->
     {error, Type, unsupported_metric_type};
 maybe_add_handler(_, Name, _, true) ->

--- a/src/folsom_metrics.erl
+++ b/src/folsom_metrics.erl
@@ -40,6 +40,7 @@
          new_duration/3,
          new_duration/4,
          new_spiral/1,
+         new_spiral/2,
          delete_metric/1,
          tag_metric/2,
          untag_metric/2,
@@ -124,6 +125,9 @@ new_duration(Name, SampleType, SampleSize, Alpha) ->
 
 new_spiral(Name) ->
     folsom_ets:add_handler(spiral, Name).
+
+new_spiral(Name, Update) ->
+    folsom_ets:add_handler(spiral, Name, Update).
 
 tag_metric(Name, Tag) ->
     folsom_ets:tag_handler(Name, Tag).


### PR DESCRIPTION
This adds new_spiral(Name, Update) where update is one of `fast`
or `no_exceptions`. `fast` works by catching the `badarg` on
update of a non-existant key. `no_exceptions` instead reads the
ETS table first to avoid catching an exception. The reason for
this is that if one uses a spiral in a cowboy onresponse
function, if there's an exception thrown by the handler it'll be
overwritten by folsom. Maybe there's another way around
this? (there's definitely https://github.com/erlang/otp/pull/362,
but I don't want to have to upgrade OTP, or wait until it's
merged)

