### PR TITLE
Link to correct metrics library

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ### folsom
 
-Folsom is an Erlang based metrics system inspired by Coda Hale's metrics (https://github.com/codahale/metrics/). The metrics API's purpose is to collect realtime metrics from your Erlang applications and publish them via Erlang APIs and output plugins. folsom is *not* a persistent store. There are 6 types of metrics: counters, gauges, histograms (and timers), histories, meter_readers and meters. Metrics can be created, read and updated via the `folsom_metrics` module.
+Folsom is an Erlang based metrics system inspired by Coda Hale's metrics (https://github.com/dropwizard/metrics). The metrics API's purpose is to collect realtime metrics from your Erlang applications and publish them via Erlang APIs and output plugins. folsom is *not* a persistent store. There are 6 types of metrics: counters, gauges, histograms (and timers), histories, meter_readers and meters. Metrics can be created, read and updated via the `folsom_metrics` module.
 
 #### Building and running
 


### PR DESCRIPTION
It looks like Coda Hale is no longer hosting the metrics library he created under his github account. The dropwizard link that I'm using was provided by the codahale/metrics repository, https://github.com/codahale/metrics.

Thanks!
